### PR TITLE
Fix exports subpath resolution and honor `silent` when maps cannot satisfy

### DIFF
--- a/.changeset/exports-subpath-silent.md
+++ b/.changeset/exports-subpath-silent.md
@@ -1,0 +1,5 @@
+---
+"resolve-sync": patch
+---
+
+Fix resolution of `exports` map subpaths: the requested subpath is now matched against the `exports` map instead of always resolving the package's root entry. Errors thrown while matching `exports`/`imports` maps that cannot satisfy the request now honor the `silent` option (returning `undefined`) instead of always throwing.

--- a/src/__tests__/index.test.ts
+++ b/src/__tests__/index.test.ts
@@ -544,6 +544,66 @@ describe("resolve - package exports", () => {
     assert.equal(result, "/project/node_modules/pkg/require.js");
   });
 
+  it("resolves an 'exports' subpath", () => {
+    const result = resolveSync("pkg/cheatsheet.md", {
+      from: "/project/src/index.js",
+      fs: vfs([
+        [
+          "/project/node_modules/pkg/package.json",
+          JSON.stringify({
+            exports: {
+              ".": "./main.js",
+              "./cheatsheet.md": "./cheatsheet.md",
+            },
+          }),
+        ],
+        "/project/node_modules/pkg/main.js",
+        "/project/node_modules/pkg/cheatsheet.md",
+      ]),
+    });
+
+    assert.equal(result, "/project/node_modules/pkg/cheatsheet.md");
+  });
+
+  it("resolves an 'exports' subpath pattern", () => {
+    const result = resolveSync("pkg/utils/parse.js", {
+      from: "/project/src/index.js",
+      fs: vfs([
+        [
+          "/project/node_modules/pkg/package.json",
+          JSON.stringify({
+            exports: {
+              "./*": "./dist/*",
+            },
+          }),
+        ],
+        "/project/node_modules/pkg/dist/utils/parse.js",
+      ]),
+    });
+
+    assert.equal(result, "/project/node_modules/pkg/dist/utils/parse.js");
+  });
+
+  it("throws if 'exports' does not include the subpath", () => {
+    assert.throws(() => {
+      resolveSync("pkg/internal.js", {
+        from: "/project/src/index.js",
+        fs: vfs([
+          [
+            "/project/node_modules/pkg/package.json",
+            JSON.stringify({
+              exports: {
+                ".": "./main.js",
+              },
+            }),
+          ],
+          "/project/node_modules/pkg/main.js",
+          "/project/node_modules/pkg/internal.js",
+        ]),
+      });
+    }, /Missing "\.\/internal\.js" specifier /);
+  });
+
   it("throws if 'exports' has no valid match", () => {
     const fs = vfs([
       [
@@ -855,6 +915,65 @@ describe("resolve - silent option", () => {
     const result = resolveSync("./missing.js", {
       from: "/project/src/index.js",
       fs: vfs(["/project/src/file.js"]),
+      silent: true,
+    });
+    assert.equal(result, undefined);
+  });
+
+  it("returns undefined instead of throwing when 'exports' does not include the subpath and silent is true", () => {
+    const result = resolveSync("pkg/internal.js", {
+      from: "/project/src/index.js",
+      fs: vfs([
+        [
+          "/project/node_modules/pkg/package.json",
+          JSON.stringify({
+            exports: {
+              ".": "./main.js",
+            },
+          }),
+        ],
+        "/project/node_modules/pkg/main.js",
+      ]),
+      silent: true,
+    });
+    assert.equal(result, undefined);
+  });
+
+  it("returns undefined instead of throwing when 'exports' conditions cannot be satisfied and silent is true", () => {
+    const result = resolveSync("pkg", {
+      from: "/project/src/index.js",
+      fs: vfs([
+        [
+          "/project/node_modules/pkg/package.json",
+          JSON.stringify({
+            exports: {
+              ".": {
+                types: "./index.d.ts",
+              },
+            },
+          }),
+        ],
+        "/project/node_modules/pkg/index.d.ts",
+      ]),
+      silent: true,
+    });
+    assert.equal(result, undefined);
+  });
+
+  it("returns undefined instead of throwing when 'imports' does not include the specifier and silent is true", () => {
+    const result = resolveSync("#missing", {
+      from: "/project/src/index.js",
+      fs: vfs([
+        [
+          "/project/package.json",
+          JSON.stringify({
+            imports: {
+              "#alias": "./src/alias.js",
+            },
+          }),
+        ],
+        "/project/src/alias.js",
+      ]),
       silent: true,
     });
     assert.equal(result, undefined);

--- a/src/index.ts
+++ b/src/index.ts
@@ -144,11 +144,7 @@ function resolveSubImport(ctx: ResolveContext, fromDir: string, id: string) {
   do {
     const pkgFile = dir + "/package.json";
     if (ctx.isFile(pkgFile)) {
-      return resolveFirst(
-        ctx,
-        dir,
-        imports(ctx.readPkg(pkgFile), id, ctx.resolve),
-      );
+      return resolveFirst(ctx, dir, matchImports(ctx, pkgFile, id));
     }
     dir = dirname(dir);
   } while (dir !== ctx.root);
@@ -224,7 +220,7 @@ function resolvePkgPart(ctx: ResolveContext, pkgDir: string, part: string) {
 
     const resolved =
       "exports" in pkg
-        ? resolveFirst(ctx, pkgDir, exports(pkg, ".", ctx.resolve))
+        ? resolveFirst(ctx, pkgDir, matchExports(ctx, pkg, part))
         : resolvePkgField(ctx, pkg, pkgDir, part);
 
     if (resolved === undefined) {
@@ -235,6 +231,26 @@ function resolvePkgPart(ctx: ResolveContext, pkgDir: string, part: string) {
     }
 
     return resolved;
+  }
+}
+
+function matchExports(ctx: ResolveContext, pkg: object, part: string) {
+  try {
+    return exports(pkg, "." + part, ctx.resolve);
+  } catch (err) {
+    // resolve.exports throws when the exports map cannot satisfy the
+    // requested subpath or conditions.
+    if (!ctx.silent) throw err;
+  }
+}
+
+function matchImports(ctx: ResolveContext, pkgFile: string, id: string) {
+  try {
+    return imports(ctx.readPkg(pkgFile) as object, id, ctx.resolve);
+  } catch (err) {
+    // resolve.exports throws when the imports map cannot satisfy the
+    // requested specifier or conditions.
+    if (!ctx.silent) throw err;
   }
 }
 


### PR DESCRIPTION
## Description

Two fixes to `exports`/`imports` map handling:

- `resolvePkgPart` passed a hardcoded `"."` to resolve.exports, so any subpath id of a package with an `exports` map (e.g. `pkg/feature.js`) resolved to the package's *root entry* instead of the requested file, or threw when the root entry had no matching condition. The requested subpath is now matched against the map (`exports(pkg, "." + part, ...)`), covered by new tests for exact subpaths, `./*` patterns, and the unexported-subpath error.
- Errors thrown by resolve.exports when an `exports` or `imports` map cannot satisfy the request (missing specifier, no matching condition) escaped the `silent` option. They now return `undefined` under `silent: true` and propagate unchanged otherwise (the existing error-message assertions still pass).

## Motivation and Context

`resolveSync("marko/cheatsheet.md", { silent: true, ... })` against published marko 6 threw `No known conditions for "." specifier in "marko" package` (its `.` entry is types-only) instead of matching the subpath or returning `undefined`. This blocks tooling that resolves non-JS files shipped inside packages — e.g. marko-js/vite#283, which points coding agents at marko's soon-to-be-exported `cheatsheet.md`.

## Checklist:

- [ ] I have updated/added documentation affected by my changes.
- [x] I have added tests to cover my changes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01KZUGLZL3YoBToFLSEv2Nys

---
_Generated by [Claude Code](https://claude.ai/code/session_01KZUGLZL3YoBToFLSEv2Nys)_