### PR TITLE
Stop the module walk at the drive root on Windows (infinite loop)

### DIFF
--- a/.changeset/windows-root-walk.md
+++ b/.changeset/windows-root-walk.md
@@ -1,0 +1,5 @@
+---
+"resolve-sync": patch
+---
+
+Fix an infinite loop when resolution fails from a Windows path: the `node_modules`/`imports` walk terminated only on reaching `root` (default `/`), which a drive-rooted path never equals — `dirname("D:/")` is `"D:/"`. The walk now also stops when a directory is its own parent (the file system root).

--- a/src/__tests__/index.test.ts
+++ b/src/__tests__/index.test.ts
@@ -844,6 +844,35 @@ describe("resolve - windows path normalization", () => {
     assert.equal(result, "C:\\project\\node_modules\\pkg\\main.js");
   });
 
+  it("throws instead of walking past the drive root when a module is missing", () => {
+    // The default root ("/") is never reached from a windows path; the walk
+    // must stop at the drive root on its own.
+    assert.throws(() => {
+      resolveSync("missing", {
+        from: "C:\\project\\src\\index.js",
+        fs: windowsVfs(["C:\\project\\src\\index.js"]),
+      });
+    }, /Cannot find module 'missing'/);
+  });
+
+  it("returns undefined instead of walking past the drive root when silent is true", () => {
+    const result = resolveSync("missing", {
+      from: "C:\\project\\src\\index.js",
+      fs: windowsVfs(["C:\\project\\src\\index.js"]),
+      silent: true,
+    });
+    assert.equal(result, undefined);
+  });
+
+  it("stops at the drive root for subpath imports with no package.json", () => {
+    const result = resolveSync("#alias", {
+      from: "C:\\project\\src\\index.js",
+      fs: windowsVfs(["C:\\project\\src\\index.js"]),
+      silent: true,
+    });
+    assert.equal(result, undefined);
+  });
+
   it("resolves extensionless file with windows paths", () => {
     const result = resolveSync("./file", {
       root: "C:\\",

--- a/src/index.ts
+++ b/src/index.ts
@@ -146,7 +146,11 @@ function resolveSubImport(ctx: ResolveContext, fromDir: string, id: string) {
     if (ctx.isFile(pkgFile)) {
       return resolveFirst(ctx, dir, matchImports(ctx, pkgFile, id));
     }
-    dir = dirname(dir);
+    const parent = dirname(dir);
+    // A directory that is its own parent is the file system root (e.g.
+    // "D:/" on Windows, which never equals the default "/" root).
+    if (parent === dir) return;
+    dir = parent;
   } while (dir !== ctx.root);
 }
 
@@ -204,7 +208,11 @@ function resolvePkg(ctx: ResolveContext, id: string) {
   do {
     const resolved = resolvePkgPart(ctx, dir + "/node_modules/" + name, part);
     if (resolved !== undefined) return resolved;
-    dir = dirname(dir);
+    const parent = dirname(dir);
+    // A directory that is its own parent is the file system root (e.g.
+    // "D:/" on Windows, which never equals the default "/" root).
+    if (parent === dir) return;
+    dir = parent;
   } while (dir !== ctx.root);
 }
 


### PR DESCRIPTION
## Description

The `node_modules` and `imports` walks terminated only on `dir !== ctx.root`, with `root` defaulting to `"/"` — which a drive-rooted Windows path never equals, since `dirname("D:/")` returns `"D:/"` itself. Any resolution that failed to resolve (missing package, or unsatisfiable exports under `silent`) therefore looped forever on Windows. Both walks now also stop when a directory is its own parent, i.e. the file system root.

Reproduced before the fix with `resolveSync("missing-pkg", { from: "C:\\project\\src\\index.js", silent: true, ... })` — hard hang, killed by timeout; after the fix it returns `undefined`. New tests cover the missing-module throw, the `silent` variant, and `#import` walks from Windows paths **without** the `root` option — the existing Windows tests all passed `root: "C:\\"`, which is why the loop was never hit in CI.

## Motivation and Context

This is what's hanging the Windows CI job in marko-js/vite (https://github.com/marko-js/vite/actions/runs/29170390485/job/86590525203) since `@marko/vite` switched its CJS detection to resolve-sync: `isCJSModule` probes bare ids with `silent: true` on every `.js` resolve, and the first unresolvable id on a Windows runner spins forever.

## Checklist:

- [ ] I have updated/added documentation affected by my changes.
- [x] I have added tests to cover my changes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01KZUGLZL3YoBToFLSEv2Nys

---
_Generated by [Claude Code](https://claude.ai/code/session_01KZUGLZL3YoBToFLSEv2Nys)_