### PR TITLE
fix: honor the root boundary and fall back to index for broken entry fields

### DIFF
--- a/.changeset/main-index-fallback.md
+++ b/.changeset/main-index-fallback.md
@@ -1,0 +1,5 @@
+---
+"resolve-sync": patch
+---
+
+Fall back to `index` when a package/directory entry field (e.g. `main`) points at a file that does not exist, matching Node's `LOAD_AS_DIRECTORY` and the `resolve`/webpack resolvers. Previously a declared-but-broken field caused resolution to throw even when an `index` file was present. A later field in `fields` is now also tried before falling back.

--- a/.changeset/root-boundary-inclusive.md
+++ b/.changeset/root-boundary-inclusive.md
@@ -1,0 +1,5 @@
+---
+"resolve-sync": patch
+---
+
+Fix the `root` boundary excluding the root directory itself. The `node_modules`/`imports` walk terminated _before_ examining `root` whenever `from` was nested below it, so `<root>/node_modules` and a `package.json` at `<root>` (for `#imports`) were never searched — breaking the documented case of setting `root` to a project directory whose dependencies live in `<root>/node_modules`. The walk now includes `root` and stops above it, and no longer probes doubled-slash paths (e.g. `//node_modules`) at a file system root. A trailing slash on `root` is also normalized.

--- a/src/__tests__/index.test.ts
+++ b/src/__tests__/index.test.ts
@@ -338,6 +338,38 @@ describe("resolve - package imports", () => {
     assert.equal(result, "/project/node_modules/pkg/index.js");
   });
 
+  it("falls back to index when a declared main points to a missing file", () => {
+    // Matches Node's LOAD_AS_DIRECTORY: a broken `main` is not fatal when an
+    // index file is present.
+    const result = resolveSync("pkg", {
+      from: "/project/src/index.js",
+      fs: vfs([
+        [
+          "/project/node_modules/pkg/package.json",
+          JSON.stringify({ main: "missing.js" }),
+        ],
+        "/project/node_modules/pkg/index.js",
+      ]),
+    });
+
+    assert.equal(result, "/project/node_modules/pkg/index.js");
+  });
+
+  it("falls through to a later field when an earlier one cannot be resolved", () => {
+    const result = resolveSync("pkg", {
+      from: "/project/src/index.js",
+      fs: vfs([
+        [
+          "/project/node_modules/pkg/package.json",
+          JSON.stringify({ module: "missing.mjs", main: "main.js" }),
+        ],
+        "/project/node_modules/pkg/main.js",
+      ]),
+    });
+
+    assert.equal(result, "/project/node_modules/pkg/main.js");
+  });
+
   it("remaps a file using browser field with './' key", () => {
     const fs = vfs([
       [
@@ -759,6 +791,90 @@ describe("resolve - subpath imports", () => {
         from: "/project/src/main.js",
       });
     }, /Cannot find module '#foo\/b'/);
+  });
+});
+
+describe("resolve - root boundary", () => {
+  it("searches the root's own node_modules when 'from' is nested below it", () => {
+    // The documented case: `root` is the project directory and the dependency
+    // lives directly in `<root>/node_modules`.
+    const result = resolveSync("pkg", {
+      from: "/project/src/index.js",
+      root: "/project",
+      fs: vfs([
+        [
+          "/project/node_modules/pkg/package.json",
+          JSON.stringify({ main: "main.js" }),
+        ],
+        "/project/node_modules/pkg/main.js",
+      ]),
+    });
+
+    assert.equal(result, "/project/node_modules/pkg/main.js");
+  });
+
+  it("normalizes a trailing slash on 'root'", () => {
+    const result = resolveSync("pkg", {
+      from: "/project/src/index.js",
+      root: "/project/",
+      fs: vfs([
+        [
+          "/project/node_modules/pkg/package.json",
+          JSON.stringify({ main: "main.js" }),
+        ],
+        "/project/node_modules/pkg/main.js",
+      ]),
+    });
+
+    assert.equal(result, "/project/node_modules/pkg/main.js");
+  });
+
+  it("does not search node_modules above the root boundary", () => {
+    assert.throws(() => {
+      resolveSync("pkg", {
+        from: "/project/src/index.js",
+        root: "/project",
+        fs: vfs([
+          [
+            "/node_modules/pkg/package.json",
+            JSON.stringify({ main: "main.js" }),
+          ],
+          "/node_modules/pkg/main.js",
+        ]),
+      });
+    }, /Cannot find module 'pkg'/);
+  });
+
+  it("resolves a subpath import from a package.json at the root boundary", () => {
+    const result = resolveSync("#alias", {
+      from: "/project/src/index.js",
+      root: "/project",
+      fs: vfs([
+        [
+          "/project/package.json",
+          JSON.stringify({ imports: { "#alias": "./src/aliased.js" } }),
+        ],
+        "/project/src/aliased.js",
+      ]),
+    });
+
+    assert.equal(result, "/project/src/aliased.js");
+  });
+
+  it("does not honor a package.json above the root boundary for subpath imports", () => {
+    assert.throws(() => {
+      resolveSync("#alias", {
+        from: "/project/src/index.js",
+        root: "/project",
+        fs: vfs([
+          [
+            "/package.json",
+            JSON.stringify({ imports: { "#alias": "./aliased.js" } }),
+          ],
+          "/aliased.js",
+        ]),
+      });
+    }, /Cannot find module '#alias'/);
   });
 });
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -97,7 +97,7 @@ export function resolveSync(
 function toContext(opts: ResolveOptions): ResolveContext {
   const fs = opts.fs || defaultFS;
   const realpath = (!opts.preserveSymlinks && fs.realpath) || identity;
-  const root = toPosix(opts.root || "/");
+  const root = normalizeRoot(toPosix(opts.root || "/"));
   const from = toPosix(opts.from);
   const fromDir = dirname(from);
   const browser = !!opts.browser;
@@ -140,18 +140,22 @@ function resolveRelative(ctx: ResolveContext, dir: string, id: string) {
 }
 
 function resolveSubImport(ctx: ResolveContext, fromDir: string, id: string) {
+  const root = ctx.root;
   let dir = fromDir;
-  do {
-    const pkgFile = dir + "/package.json";
+  for (;;) {
+    const pkgFile = joinDir(dir) + "package.json";
     if (ctx.isFile(pkgFile)) {
       return resolveFirst(ctx, dir, matchImports(ctx, pkgFile, id));
     }
+    // Stop after checking `root` itself so a package.json at the boundary is
+    // honored, but nothing above it is searched.
+    if (dir === root) return;
     const parent = dirname(dir);
     // A directory that is its own parent is the file system root (e.g.
     // "D:/" on Windows, which never equals the default "/" root).
     if (parent === dir) return;
     dir = parent;
-  } while (dir !== ctx.root);
+  }
 }
 
 function resolveFirst(
@@ -205,15 +209,23 @@ function resolvePkg(ctx: ResolveContext, id: string) {
     }
   }
 
-  do {
-    const resolved = resolvePkgPart(ctx, dir + "/node_modules/" + name, part);
+  const root = ctx.root;
+  for (;;) {
+    const resolved = resolvePkgPart(
+      ctx,
+      joinDir(dir) + "node_modules/" + name,
+      part,
+    );
     if (resolved !== undefined) return resolved;
+    // Stop after searching `root` itself so its node_modules is included, but
+    // nothing above it is searched.
+    if (dir === root) return;
     const parent = dirname(dir);
     // A directory that is its own parent is the file system root (e.g.
     // "D:/" on Windows, which never equals the default "/" root).
     if (parent === dir) return;
     dir = parent;
-  } while (dir !== ctx.root);
+  }
 }
 
 function resolvePkgPart(ctx: ResolveContext, pkgDir: string, part: string) {
@@ -284,7 +296,10 @@ function resolvePkgField(
   for (const field of ctx.fields) {
     const value = (pkg as Record<string, unknown>)[field];
     if (typeof value === "string") {
-      return resolveRelative(ctx, pkgDir, value);
+      const resolved = resolveRelative(ctx, pkgDir, value);
+      // Like Node's LOAD_AS_DIRECTORY, a field that points at a missing file
+      // is not fatal: fall through to the next field and finally to `index`.
+      if (resolved !== undefined) return resolved;
     }
   }
 
@@ -339,6 +354,24 @@ function getBrowserRemap(
       }
     }
   }
+}
+
+function normalizeRoot(root: string) {
+  const end = root.length - 1;
+  // Drop a trailing slash so the boundary compares equal to the canonical
+  // directories produced while walking. `dirname` never yields a trailing
+  // slash except at a filesystem root ("/" or "C:/"), which we keep as-is.
+  return end > 0 &&
+    root.charCodeAt(end) === 47 /* "/" */ &&
+    !(end === 2 && root.charCodeAt(1) === 58) /* drive root like "C:/" */
+    ? root.slice(0, end)
+    : root;
+}
+
+function joinDir(dir: string) {
+  // Append a trailing slash unless `dir` is already a filesystem root ("/" or
+  // "C:/"), which avoids emitting a doubled slash when building child paths.
+  return dir.charCodeAt(dir.length - 1) === 47 /* "/" */ ? dir : dir + "/";
 }
 
 function dirname(dir: string) {


### PR DESCRIPTION
## Description

Two resolution correctness fixes:

**1. The `root` option no longer excludes the root directory itself.** The `node_modules`/`imports` walk was a `do…while (dir !== root)` that only tested the condition *after* stepping to the parent, so it stopped one directory short of `root` whenever `from` was nested below it. As a result `<root>/node_modules` — and a `package.json` at `<root>` for `#imports` — were never searched. That is exactly the documented case (pointing `root` at a project directory whose dependencies live in `<root>/node_modules`), which threw `Cannot find module`. The bug was masked in day-to-day use because the default `root` is `/`, where the only unsearched directory is the near-useless `/node_modules`.

The walk now runs until it has examined `root` itself and stops above it. As a side effect it no longer probes doubled-slash paths (e.g. `//node_modules`) at a file system root, and a trailing slash on `root` is normalized so `"/project/"` behaves like `"/project"`.

**2. A broken entry field falls back to `index`.** When a package/directory entry field (e.g. `main`) pointed at a file that does not exist, resolution threw even when an `index` file was present. It now falls through to a later field in `fields` and finally to `index`, matching Node's `LOAD_AS_DIRECTORY` and the `resolve`/webpack resolvers. A genuinely unresolvable package (no working field and no index) still throws as before.

## Motivation and Context

The `root` behavior contradicted the README, which states resolution "won't ascend beyond this directory" and "will not resolve modules outside of `/project`" — implying `<root>/node_modules` *is* in scope. In practice, setting `root` to a real project directory broke package and subpath-import resolution. The index-fallback change aligns with the stated goal of "resolving in the same way node and bundlers do," verified against `require.resolve` and the `resolve` package.

Both fixes are additive/relaxing (they turn former throws into successful resolutions) and keep the existing boundary and error semantics: nothing above `root` is searched, and truly missing entries still throw.

## Screenshots (if appropriate):

N/A

## Checklist:

- [ ] I have updated/added documentation affected by my changes.
- [x] I have added tests to cover my changes.


---
_Generated by [Claude Code](https://claude.ai/code/session_01Pso3346vQ44susSajcdNDT)_